### PR TITLE
Index from 1 for the Bank Index UI

### DIFF
--- a/loadstone_front/src/app/menus/memory_map/mod.rs
+++ b/loadstone_front/src/app/menus/memory_map/mod.rs
@@ -175,7 +175,7 @@ fn configure_internal_bank(
             .clamp_to_range(true)
             .suffix("KB"),
         );
-        ui.label(format!("Bank {}", i));
+        ui.label(format!("Bank {}", i + 1));
         ui.add(
             Label::new(format!("(0x{:x} - 0x{:x})", bank.start_address, bank.end_address()))
                 .text_color(Color32::LIGHT_BLUE),
@@ -277,7 +277,7 @@ fn configure_external_bank(
             .clamp_to_range(true)
             .suffix("KB"),
         );
-        ui.label(format!("Bank {}", global_index));
+        ui.label(format!("Bank {}", global_index + 1));
         ui.add(
             Label::new(format!("(0x{:x} - 0x{:x})", bank.start_address, bank.end_address()))
                 .text_color(Color32::LIGHT_BLUE),


### PR DESCRIPTION
In all "user visible" parts of Loadstone (serial, CLI, etc) banks are 1-indexed. The Loadstone Builder showed the banks as 0 indexed instead, which was confusing.